### PR TITLE
remove 'version' from docker compose

### DIFF
--- a/docker-compose.multiple.yml
+++ b/docker-compose.multiple.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   pihole:
     container_name: pihole

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 services:
   pihole:
     container_name: pihole


### PR DESCRIPTION
`version` parameter is [considered](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete) obsolete